### PR TITLE
Option to build FFlLib without vertex and visualisation attributes

### DIFF
--- a/src/Admin/CMakeLists.txt
+++ b/src/Admin/CMakeLists.txt
@@ -17,7 +17,8 @@ Date ( "build_date" "${CMAKE_CURRENT_BINARY_DIR}" ) # Generate new build date
 
 # Extract new build number as the patch number from the file "cfg/VERSION"
 # and write it out to "build_no.h" in the build directory
-find_file ( VERSION "VERSION" PATHS ${PROJECT_SOURCE_DIR}/cfg NO_DEFAULT_PATH )
+find_file ( VERSION "VERSION" PATHS ${PROJECT_SOURCE_DIR}/cfg
+                                    ${CONFIG_DIR} NO_DEFAULT_PATH )
 if ( VERSION )
   message ( STATUS "INFORMATION : Extracting build number from ${VERSION}" )
   file ( READ ${VERSION} BUILD_NO )

--- a/src/FFlLib/CMakeLists.txt
+++ b/src/FFlLib/CMakeLists.txt
@@ -20,6 +20,10 @@ if ( USE_PROFILER )
   string ( APPEND CMAKE_CXX_FLAGS " -DFFL_TIMER" )
 endif ( USE_PROFILER )
 
+if ( USE_VERTEXOBJ OR USE_VTFX )
+  string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_VERTEX" )
+endif ( USE_VERTEXOBJ OR USE_VTFX )
+
 if ( USE_MEMPOOL )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
 endif ( USE_MEMPOOL )
@@ -40,8 +44,11 @@ set ( COMPONENT_FILE_LIST FFlAttributeBase FFlConnectorItems FFlElementBase
                           FFlFEElementTopSpec FFlFENodeRefs FFlFieldBase
                           FFlGroup FFlLinkHandler FFlLoadBase FFlMemPool
                           FFlNamedPartBase FFlPartBase FFlUtils
-                          FFlVertex FFlVisualBase FFlVisualRefs
+                          FFlVisualBase FFlVisualRefs
 )
+if ( USE_VERTEXOBJ OR USE_VTFX )
+  list ( APPEND COMPONENT_FILE_LIST FFlVertex )
+endif ( USE_VERTEXOBJ OR USE_VTFX )
 
 ## Pure header files, i.e., header files without a corresponding source file
 set ( HEADER_FILE_LIST FFlFEResultBase FFlField
@@ -76,7 +83,11 @@ foreach ( FILE ${F90_FILE_LIST} )
 endforeach ( FILE ${F90_FILE_LIST} )
 
 
-set ( DEPENDENCY_LIST FFlFEParts FFlIOAdaptors FFaAlgebra FFaDefinitions )
+set ( DEPENDENCY_LIST FFlFEParts FFaAlgebra FFaDefinitions )
+
+if ( "${APPLICATION_ID}" STREQUAL "fedemKernel" )
+  list ( INSERT DEPENDENCY_LIST 0 FFlIOAdaptors )
+endif ( "${APPLICATION_ID}" STREQUAL "fedemKernel" )
 
 if ( USE_MEMPOOL )
   list ( APPEND DEPENDENCY_LIST FFaPatterns )

--- a/src/FFlLib/CMakeLists.txt
+++ b/src/FFlLib/CMakeLists.txt
@@ -24,6 +24,10 @@ if ( USE_VERTEXOBJ OR USE_VTFX )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_VERTEX" )
 endif ( USE_VERTEXOBJ OR USE_VTFX )
 
+if ( USE_VISUALS )
+  string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_VISUALS" )
+endif ( USE_VISUALS )
+
 if ( USE_MEMPOOL )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
 endif ( USE_MEMPOOL )
@@ -44,11 +48,13 @@ set ( COMPONENT_FILE_LIST FFlAttributeBase FFlConnectorItems FFlElementBase
                           FFlFEElementTopSpec FFlFENodeRefs FFlFieldBase
                           FFlGroup FFlLinkHandler FFlLoadBase FFlMemPool
                           FFlNamedPartBase FFlPartBase FFlUtils
-                          FFlVisualBase FFlVisualRefs
 )
 if ( USE_VERTEXOBJ OR USE_VTFX )
   list ( APPEND COMPONENT_FILE_LIST FFlVertex )
 endif ( USE_VERTEXOBJ OR USE_VTFX )
+if ( USE_VISUALS )
+  list ( APPEND COMPONENT_FILE_LIST FFlVisualBase FFlVisualRefs )
+endif ( USE_VISUALS )
 
 ## Pure header files, i.e., header files without a corresponding source file
 set ( HEADER_FILE_LIST FFlFEResultBase FFlField

--- a/src/FFlLib/FFlElementBase.C
+++ b/src/FFlLib/FFlElementBase.C
@@ -8,6 +8,9 @@
 #include "FFlLib/FFlElementBase.H"
 #include "FFlLib/FFlFEElementTopSpec.H"
 #include "FFlLib/FFlFEAttributeSpec.H"
+#if !defined(FT_USE_VISUALS) && defined(FFL_DEBUG)
+#include "FFlLib/FFlLinkCSMask.H"
+#endif
 #include "FFlLib/FFlFEResultBase.H"
 #include "FFlLib/FFlFEParts/FFlPMAT.H"
 #include "FFaLib/FFaAlgebra/FFaCheckSum.H"
@@ -23,8 +26,12 @@ FFlElementBase::FFlElementBase(int id) : FFlPartBase(id)
 
 
 FFlElementBase::FFlElementBase(const FFlElementBase& obj)
-  : FFlPartBase(obj), FFlFEAttributeRefs(obj), FFlFENodeRefs(obj),
-    FFlVisualRefs(obj)
+  : FFlPartBase(obj), FFlFEAttributeRefs(obj),
+#ifdef FT_USE_VISUALS
+    FFlFENodeRefs(obj), FFlVisualRefs(obj)
+#else
+    FFlFENodeRefs(obj)
+#endif
 {
   calculateResults = true;
   myResults = NULL;
@@ -37,12 +44,22 @@ FFlElementBase::~FFlElementBase()
 }
 
 
+#if defined(FT_USE_VISUALS) || defined(FFL_DEBUG)
 void FFlElementBase::calculateChecksum(FFaCheckSum* cs, int cstype) const
+#else
+void FFlElementBase::calculateChecksum(FFaCheckSum* cs, int) const
+#endif
 {
   FFlPartBase::checksum(cs);
   FFlFEAttributeRefs::checksum(cs);
   FFlFENodeRefs::checksum(cs);
+#if defined(FT_USE_VISUALS)
   FFlVisualRefs::checksum(cs,cstype);
+#elif defined(FFL_DEBUG)
+  if ((cstype & FFl::CS_VISUALMASK) != FFl::CS_NOVISUALINFO)
+    std::cout <<"FFlElementBase::calculateChecksum: Visuals ignored"
+              << std::endl;
+#endif
 }
 
 

--- a/src/FFlLib/FFlElementBase.H
+++ b/src/FFlLib/FFlElementBase.H
@@ -11,7 +11,9 @@
 #include "FFlLib/FFlPartBase.H"
 #include "FFlLib/FFlFEAttributeRefs.H"
 #include "FFlLib/FFlFENodeRefs.H"
+#ifdef FT_USE_VISUALS
 #include "FFlLib/FFlVisualRefs.H"
+#endif
 #include "FFlLib/FFlTypeInfoSpec.H"
 #include "FFaLib/FFaPatterns/FFaGenericFactory.H"
 
@@ -26,8 +28,12 @@ class FaVec3;
 
 class FFlElementBase : public FFlPartBase,
 		       public FFlFEAttributeRefs,
+#ifdef FT_USE_VISUALS
 		       public FFlFENodeRefs,
 		       public FFlVisualRefs
+#else
+		       public FFlFENodeRefs
+#endif
 {
 protected:
   typedef std::vector<FFlElementBase*> Elements;
@@ -80,6 +86,10 @@ public:
   bool hasResults() const { return myResults != NULL; }
   FFlFEElmResult* getResults();
   void deleteResults();
+
+#ifndef FT_USE_VISUALS
+  bool isVisible() const { return true; }
+#endif
 
 private:
   FFlFEResultBase* myResults;

--- a/src/FFlLib/FFlFEParts/CMakeLists.txt
+++ b/src/FFlLib/FFlFEParts/CMakeLists.txt
@@ -24,9 +24,11 @@ set ( COMPONENT_FILE_LIST FFlAllFEParts FFlBEAM2 FFlBEAM3 FFlBUSH
                           FFlPSTRC FFlPTHICK FFlPTHICKREF FFlPWAVGM
                           FFlQUAD4 FFlQUAD8 FFlRBAR FFlRGD FFlShellElementBase
                           FFlSPRING FFlSTRCoat FFlTET10 FFlTET4
-                          FFlTRI3 FFlTRI6 FFlVAppearance FFlVDetail
-                          FFlWAVGM FFlWEDG15 FFlWEDG6
+                          FFlTRI3 FFlTRI6 FFlWAVGM FFlWEDG15 FFlWEDG6
 )
+if ( USE_VISUALS )
+  list ( APPEND COMPONENT_FILE_LIST FFlVAppearance FFlVDetail )
+endif ( USE_VISUALS )
 
 
 foreach ( FILE ${COMPONENT_FILE_LIST} )

--- a/src/FFlLib/FFlFEParts/FFlAllFEParts.C
+++ b/src/FFlLib/FFlFEParts/FFlAllFEParts.C
@@ -75,8 +75,10 @@ void FFl::initAllElements()
   FFlPTHICKREF::init();
   FFlPFATIGUE::init();
 
+#ifdef FT_USE_VISUALS
   FFlVAppearance::init();
   FFlVDetail::init();
+#endif
 
   FFlGroup::init();
 
@@ -162,9 +164,11 @@ void FFl::releaseAllElements()
   releaseAttribute<FFlPFATIGUE>();
   AttributeFactory::removeInstance();
 
+#ifdef FT_USE_VISUALS
   FFlVAppearanceTypeInfoSpec::removeInstance();
   FFlVDetailTypeInfoSpec::removeInstance();
   VisualFactory::removeInstance();
+#endif
 
   FFlGroupTypeInfoSpec::removeInstance();
 

--- a/src/FFlLib/FFlFEParts/FFlNode.H
+++ b/src/FFlLib/FFlFEParts/FFlNode.H
@@ -15,15 +15,18 @@
 #include "FFaLib/FFaPatterns/FFaMemPool.H"
 #endif
 #include "FFaLib/FFaPatterns/FFaSingelton.H"
-
+#ifndef FT_USE_VERTEX
+#include "FFaLib/FFaAlgebra/FFaVec3.H"
+#else
+class FaVec3;
 class FFlVertex;
+#endif
 class FFlPCOORDSYS;
 class FFlAttributeBase;
 class FFlFEResultBase;
 class FFlFENodeResult;
 class FFaUnitCalculator;
 class FFaCheckSum;
-class FaVec3;
 
 
 class FFlNode : public FFlPartBase
@@ -48,12 +51,17 @@ public:
 
   // Vertex management:
 
+#ifdef FT_USE_VERTEX
   int getVertexID() const;
 
   void setVertex(FFlVertex* aVertex);
   FFlVertex* getVertex() const { return myVertex; }
   const FaVec3& getPos() const;
   FaVec3& position() { return const_cast<FaVec3&>(this->getPos()); }
+#else
+  const FaVec3& getPos() const { return myPos; }
+  FaVec3& position() { return myPos; }
+#endif
 
   // Node status management:
 
@@ -98,7 +106,11 @@ public:
 protected:
   char             status; // 0=internal, 1=external, 2=slavenode(internal)
   char             myDOFCount;
+#ifdef FT_USE_VERTEX
   FFlVertex*       myVertex;
+#else
+  FaVec3           myPos;
+#endif
   FFlFEResultBase* myResults;
 
   FFlReference<FFlAttributeBase> myLocalSystem; // solution coordinate system

--- a/src/FFlLib/FFlFEParts/FFlNode.H
+++ b/src/FFlLib/FFlFEParts/FFlNode.H
@@ -53,6 +53,7 @@ public:
   void setVertex(FFlVertex* aVertex);
   FFlVertex* getVertex() const { return myVertex; }
   const FaVec3& getPos() const;
+  FaVec3& position() { return const_cast<FaVec3&>(this->getPos()); }
 
   // Node status management:
 

--- a/src/FFlLib/FFlIOAdaptors/FFlFedemReader.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlFedemReader.C
@@ -17,7 +17,9 @@
 #include "FFlLib/FFlLoadBase.H"
 #include "FFlLib/FFlAttributeBase.H"
 #include "FFlLib/FFlFEAttributeSpec.H"
+#ifdef FT_USE_VISUALS
 #include "FFlLib/FFlVisualBase.H"
+#endif
 #include "FFlLib/FFlFieldBase.H"
 #include "FFlLib/FFlGroup.H"
 
@@ -79,11 +81,13 @@ FFlFedemReader::FFlFedemReader(FFlLinkHandler* aLink) : FFlReaderBase(aLink)
     myFieldResolvers[key] = FFaDynCB1M(FFlFedemReader, this,
 				       resolveAttributeField, const ftlField&);
 
+#ifdef FT_USE_VISUALS
   // get visual keys:
   VisualFactory::instance()->getKeys(keys);
   for (const std::string& key : keys)
     myFieldResolvers[key] = FFaDynCB1M(FFlFedemReader, this,
 				       resolveVisualField, const ftlField&);
+#endif
 
 #ifdef FFL_DEBUG
   std::cout <<"Registered field resolvers"<< std::endl;
@@ -273,7 +277,11 @@ void FFlFedemReader::resolveElementField(const ftlField& field)
     for (const RefFieldMap::value_type& ref : field.refs)
       if (!ref.second.id.empty())
       {
+#ifdef FT_USE_VISUALS
         if (newElem->setVisual(ref.first,ref.second.id.front()))
+#else
+        if (ref.first[0] == 'V')
+#endif
           continue;
         else if (ref.first == "FE") // reference to other finite element
           newElem->setFElement(ref.second.id.front());
@@ -375,6 +383,7 @@ void FFlFedemReader::resolveAttributeField(const ftlField& field)
 }
 
 
+#ifdef FT_USE_VISUALS
 void FFlFedemReader::resolveVisualField(const ftlField& field)
 {
   START_TIMER("resolveVisualField");
@@ -400,6 +409,9 @@ void FFlFedemReader::resolveVisualField(const ftlField& field)
   if (nErr > lErr) parseError(nErr-lErr,field.label,field.entries[0]);
   STOPP_TIMER("resolveVisualField");
 }
+#else
+void FFlFedemReader::resolveVisualField(const ftlField&) {}
+#endif
 
 
 void FFlFedemReader::resolveGroupField(const ftlField& field)

--- a/src/FFlLib/FFlIOAdaptors/FFlFedemWriter.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlFedemWriter.C
@@ -13,7 +13,9 @@
 #include "FFlLib/FFlElementBase.H"
 #include "FFlLib/FFlLoadBase.H"
 #include "FFlLib/FFlAttributeBase.H"
+#ifdef FT_USE_VISUALS
 #include "FFlLib/FFlVisualBase.H"
+#endif
 #include "FFlLib/FFlGroup.H"
 #include "FFlLib/FFlFieldBase.H"
 
@@ -139,11 +141,13 @@ bool FFlFedemWriter::writeElementData(std::ostream& os) const
       if (aIt->second.isResolved())
         os <<" {"<< aIt->second->getTypeName() <<" "<< aIt->second->getID() <<"}";
 
+#ifdef FT_USE_VISUALS
     FFlVisualBase* vapp = curElm->getVisualAppearance();
     if (vapp) os <<" {"<< vapp->getTypeName() <<" "<< vapp->getID() <<"}";
 
     FFlVisualBase* vdet = curElm->getVisualDetail();
     if (vdet) os <<" {"<< vdet->getTypeName() <<" "<< vdet->getID() <<"}";
+#endif
 
     FFlElementBase* refElm = curElm->getFElement();
     if (refElm) os <<" {FE "<< refElm->getID() <<"}";
@@ -246,6 +250,7 @@ bool FFlFedemWriter::writeAttributeData(std::ostream& os) const
 }
 
 
+#ifdef FT_USE_VISUALS
 bool FFlFedemWriter::writeVisualData(std::ostream& os) const
 {
   if (myLink->visualsBegin() != myLink->visualsEnd())
@@ -260,3 +265,6 @@ bool FFlFedemWriter::writeVisualData(std::ostream& os) const
 
   return os ? true : false;
 }
+#else
+bool FFlFedemWriter::writeVisualData(std::ostream&) const { return true; }
+#endif

--- a/src/FFlLib/FFlIOAdaptors/FFlNastranResolver.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlNastranResolver.C
@@ -8,7 +8,6 @@
 #include "FFlLib/FFlIOAdaptors/FFlNastranReader.H"
 #include "FFlLib/FFlLinkHandler.H"
 #include "FFlLib/FFlElementBase.H"
-#include "FFlLib/FFlVertex.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
 #include "FFlLib/FFlFEParts/FFlPORIENT.H"
 #include "FFlLib/FFlFEParts/FFlPBEAMSECTION.H"
@@ -135,7 +134,7 @@ bool FFlNastranReader::resolveCoordinates ()
   // digits to avoid checksum issues when saving and reopening the model
 
   for (NodesCIter n = myLink->nodesBegin(); n != myLink->nodesEnd(); ++n)
-    (*n)->getVertex()->round(10);
+    (*n)->position().round(10);
 
   // Add all local coordinate systems which are not referred by any elements
   // to the link object. They may be used to aid the mechanism modeling later.
@@ -168,7 +167,7 @@ bool FFlNastranReader::transformNode (IntMap::iterator& nit)
   std::cout <<" Transforming node "<< nit->first <<", CP = "<< CP;
 #endif
 
-  bool ok = this->transformPoint(*myLink->getNode(nit->first)->getVertex(),CP);
+  bool ok = this->transformPoint(myLink->getNode(nit->first)->position(),CP);
   nodeCPID.erase(nit);
   return ok;
 }
@@ -828,11 +827,11 @@ bool FFlNastranReader::resolveWeldElement (FFlElementBase* curElm,
           }
 
           // Get the global position of all patch vertices
-          std::vector<FaVec3*> vx;
+          std::vector<FaVec3> vx;
           FFlNode* pchNode;
           for (size_t k = 1; k < G.size(); k++)
             if ((pchNode = myLink->getNode(G[k])))
-              vx.push_back(pchNode->getVertex());
+              vx.push_back(pchNode->getPos());
             else
             {
               ok = false;
@@ -843,9 +842,9 @@ bool FFlNastranReader::resolveWeldElement (FFlElementBase* curElm,
           // where the surface normal defines the local Z-axis
           FaMat34 Tpch;
           if (vx.size() == 3)
-            Tpch.makeGlobalizedCS(*vx[0],*vx[1],*vx[2]);
+            Tpch.makeGlobalizedCS(vx[0],vx[1],vx[2]);
           else if (vx.size() == 4)
-            Tpch.makeGlobalizedCS(*vx[0],*vx[1],*vx[2],*vx[3]);
+            Tpch.makeGlobalizedCS(vx[0],vx[1],vx[2],vx[3]);
           else
             ok = false;
 

--- a/src/FFlLib/FFlIOAdaptors/FFlVTFWriter.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlVTFWriter.C
@@ -9,8 +9,7 @@
 #include "FFlLib/FFlLinkHandler.H"
 #include "FFlLib/FFlElementBase.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
-#include "FFlLib/FFlVertex.H"
-
+#include "FFaLib/FFaAlgebra/FFaVec3.H"
 #include "FFaLib/FFaDefinitions/FFaMsg.H"
 #ifdef FFL_TIMER
 #include "FFaLib/FFaProfiler/FFaProfiler.H"
@@ -99,13 +98,13 @@ bool FFlVTFWriter::writeNodes(int, bool)
     if ((*nit)->hasDOFs() &&
         (myNodes.empty() || myNodes.find((*nit)->getID()) != myNodes.end()))
     {
-      const FFlVertex* v = (*nit)->getVertex();
+      const FaVec3& v = (*nit)->getPos();
       int nID = (*nit)->getID();
       if (withID)
-        ok = VTFA_SUCCESS(nodeBlock.AddNode(v->x(),v->y(),v->z(),nID));
+        ok = VTFA_SUCCESS(nodeBlock.AddNode(v.x(),v.y(),v.z(),nID));
       else
       {
-        ok = VTFA_SUCCESS(nodeBlock.AddNode(v->x(),v->y(),v->z()));
+        ok = VTFA_SUCCESS(nodeBlock.AddNode(v.x(),v.y(),v.z()));
         myNodMap[nID] = inod++;
       }
     }

--- a/src/FFlLib/FFlLinkHandler.H
+++ b/src/FFlLib/FFlLinkHandler.H
@@ -47,8 +47,10 @@ typedef std::map<std::string,size_t>     ElmTypeCount;
 typedef std::vector<FFlNode*>            NodesVec;
 typedef NodesVec::const_iterator         NodesCIter;
 
+#ifdef FT_USE_VERTEX
 typedef std::vector<FaVec3*>             VertexVec;
 typedef VertexVec::const_iterator        VertexCIter;
+#endif
 
 typedef std::map<int,FFlGroup*>          GroupMap;
 typedef GroupMap::const_iterator         GroupCIter;
@@ -134,7 +136,9 @@ public:
   ElementsCIter elementsBegin()  const { return myElements.begin(); }
   ElementsCIter fElementsBegin() const { return myFElements.begin(); }
   NodesCIter    nodesBegin()     const { return myNodes.begin(); }
+#ifdef FT_USE_VERTEX
   VertexCIter   verticesBegin()  const { return myVertices.begin(); }
+#endif
   GroupCIter    groupsBegin()    const { return myGroupMap.begin(); }
   LoadsCIter    loadsBegin()     const { return myLoads.begin(); }
   VisualsCIter  visualsBegin()   const { return myVisuals.begin(); }
@@ -146,7 +150,9 @@ public:
   ElementsCIter elementsEnd()  const { return myElements.end(); }
   ElementsCIter fElementsEnd() const { return myFElements.end(); }
   NodesCIter    nodesEnd()     const { return myNodes.end(); }
+#ifdef FT_USE_VERTEX
   VertexCIter   verticesEnd()  const { return myVertices.end(); }
+#endif
   GroupCIter    groupsEnd()    const { return myGroupMap.end(); }
   LoadsCIter    loadsEnd()     const { return myLoads.end(); }
   VisualsCIter  visualsEnd()   const { return myVisuals.end(); }
@@ -157,6 +163,7 @@ public:
 
   // Special vertex management access :
 
+#ifdef FT_USE_VERTEX
   size_t getVertexCount() const { return myVertices.size(); }
   const VertexVec& getVertexes() const { return myVertices; }
   const FaVec3& getVertexPos(size_t idx) const { return *myVertices[idx]; }
@@ -165,6 +172,7 @@ public:
 
   // For each vertex, a vector of elements with the local index of the vertex
   const FFlrVxToElmMap& getVxToElementMapping();
+#endif
 
   void getAllInternalCoordSys(std::vector<FaMat34>& mxes) const;
 
@@ -297,8 +305,10 @@ protected:
 
   GroupMap              myGroupMap;
   AttributeTypeMap      myAttributes;
+#ifdef FT_USE_VERTEX
   VertexVec             myVertices;
   FFlrVxToElmMap        myVxMapping;
+#endif
 
   bool                  isResolved;    // Flag to avoid resolving more than once
   bool                  hasLooseNodes; // true if unconnected nodes are present

--- a/src/FFlLib/FFlLinkHandler.H
+++ b/src/FFlLib/FFlLinkHandler.H
@@ -62,8 +62,10 @@ typedef std::map<int,FFlAttributeBase*>    AttributeMap;
 typedef std::map<std::string,AttributeMap> AttributeTypeMap;
 typedef AttributeTypeMap::const_iterator   AttributeTypeCIter;
 
+#ifdef FT_USE_VISUALS
 typedef std::vector<FFlVisualBase*>        VisualsVec;
 typedef VisualsVec::const_iterator         VisualsCIter;
+#endif
 
 typedef std::pair<FFlElementBase*,int> FFlrElement;
 typedef std::vector<FFlrElement>       FFlrElementVec;
@@ -89,9 +91,11 @@ public:
   bool addAttribute(FFlAttributeBase* attr, bool silence, const std::string& name);
   int  addUniqueAttribute(FFlAttributeBase* newAtt, bool silence = false);
   bool removeAttribute(const std::string& typeName, int ID, bool silence = false);
+#ifdef FT_USE_VISUALS
   void addVisual(FFlVisualBase* visual, bool sortOnInsert = false);
-
   void setRunningIdxOnAppearances();
+#endif
+
   int  sortElementsAndNodes(bool deleteDuplicates = false) const;
 
   // Getting count of entities
@@ -129,7 +133,9 @@ public:
   int getNewNodeID() const;
   int getNewGroupID() const;
   int getNewAttribID(const std::string& type) const;
+#ifdef FT_USE_VISUALS
   int getNewVisualID() const;
+#endif
 
   // Begin iterators to the containers
 
@@ -141,8 +147,9 @@ public:
 #endif
   GroupCIter    groupsBegin()    const { return myGroupMap.begin(); }
   LoadsCIter    loadsBegin()     const { return myLoads.begin(); }
+#ifdef FT_USE_VISUALS
   VisualsCIter  visualsBegin()   const { return myVisuals.begin(); }
-
+#endif
   AttributeTypeCIter attributeTypesBegin() const { return myAttributes.begin(); }
 
   // End iterators to the containers
@@ -155,8 +162,9 @@ public:
 #endif
   GroupCIter    groupsEnd()    const { return myGroupMap.end(); }
   LoadsCIter    loadsEnd()     const { return myLoads.end(); }
+#ifdef FT_USE_VISUALS
   VisualsCIter  visualsEnd()   const { return myVisuals.end(); }
-
+#endif
   AttributeTypeCIter attributeTypesEnd() const { return myAttributes.end(); }
 
   const AttributeMap& getAttributes(const std::string& name) const;
@@ -233,6 +241,7 @@ public:
   bool updateCalculationFlag(FFlPartBase* part, bool status = true);
   bool updateCalculationFlag(const std::string& attType, int id, bool status = true);
 
+#ifdef FT_USE_VISUALS
   // Visual settings
   bool setVisDetail(const FFlVDetail* det); // on all elements
   bool setVisDetail(FFlPartBase* part, const FFlVDetail* det);
@@ -244,6 +253,7 @@ public:
   FFlVDetail* getPredefDetail(int detailType);
   FFlVDetail* getOnDetail();
   FFlVDetail* getOffDetail();
+#endif
 
   // For external Nastran files
   void addComponentModes(int nGen) { nGenDofs += nGen; }
@@ -284,7 +294,9 @@ protected:
   int  sortElements(bool deleteDuplicates = false) const;
   int  sortNodes(bool deleteDuplicates = false) const;
   void sortLoads() const;
+#ifdef FT_USE_VISUALS
   void sortVisuals() const;
+#endif
 
   // Model size limits :
 
@@ -300,8 +312,10 @@ protected:
   mutable bool          areNodesSorted;
   mutable LoadsVec      myLoads;
   mutable bool          areLoadsSorted;
+#ifdef FT_USE_VISUALS
   mutable VisualsVec    myVisuals;
   mutable bool          areVisualsSorted;
+#endif
 
   GroupMap              myGroupMap;
   AttributeTypeMap      myAttributes;

--- a/src/FFlLib/FFlMemPool.C
+++ b/src/FFlLib/FFlMemPool.C
@@ -6,7 +6,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "FFlLib/FFlMemPool.H"
+#ifdef FT_USE_MEMPOOL
+#ifdef FT_USE_VERTEX
 #include "FFlLib/FFlVertex.H"
+#endif
 #include "FFlLib/FFlFEParts/FFlNode.H"
 #include "FFlLib/FFlFEParts/FFlCMASS.H"
 #include "FFlLib/FFlFEParts/FFlSPRING.H"
@@ -28,11 +31,12 @@
 #include "FFlLib/FFlFEParts/FFlWAVGM.H"
 #include "FFlLib/FFlFEParts/FFlSTRCoat.H"
 
-#ifdef FT_USE_MEMPOOL
 typedef FFaSingelton<FFaMemPoolMgr,FFlElementBase> FFlMemPoolMgr;
 
 FFaMemPool FFlNode   ::ourMemPool(sizeof(FFlNode));
+#ifdef FT_USE_VERTEX
 FFaMemPool FFlVertex ::ourMemPool(sizeof(FFlVertex));
+#endif
 FFaMemPool FFlCMASS  ::ourMemPool(sizeof(FFlCMASS)  ,FFlMemPoolMgr::instance());
 FFaMemPool FFlSPRING ::ourMemPool(sizeof(FFlSPRING) ,FFlMemPoolMgr::instance());
 FFaMemPool FFlRSPRING::ourMemPool(sizeof(FFlRSPRING),FFlMemPoolMgr::instance());
@@ -63,7 +67,9 @@ void FFlMemPool::deleteAllLinkMemPools()
 {
 #ifdef FT_USE_MEMPOOL
   FFlNode::freePool();
+#ifdef FT_USE_VERTEX
   FFlVertex::freePool();
+#endif
   FFlMemPoolMgr::removeInstance();
 #endif
 }
@@ -76,8 +82,9 @@ void FFlMemPool::setAsMemPoolPart(FFlLinkHandler*
                                   ){
 #ifdef FT_USE_MEMPOOL
   FFlNode   ::usePartOfPool(link);
+#ifdef FT_USE_VERTEX
   FFlVertex ::usePartOfPool(link);
-
+#endif
   FFlCMASS  ::usePartOfPool(link);
   FFlSPRING ::usePartOfPool(link);
   FFlRSPRING::usePartOfPool(link);
@@ -112,8 +119,9 @@ void FFlMemPool::freeMemPoolPart(FFlLinkHandler*
                                  ){
 #ifdef FT_USE_MEMPOOL
   FFlNode   ::freePartOfPool(link);
+#ifdef FT_USE_VERTEX
   FFlVertex ::freePartOfPool(link);
-
+#endif
   FFlCMASS  ::freePartOfPool(link);
   FFlSPRING ::freePartOfPool(link);
   FFlRSPRING::freePartOfPool(link);
@@ -145,8 +153,9 @@ void FFlMemPool::resetMemPoolPart()
 {
 #ifdef FT_USE_MEMPOOL
   FFlNode   ::useDefaultPartOfPool();
+#ifdef FT_USE_VERTEX
   FFlVertex ::useDefaultPartOfPool();
-
+#endif
   FFlCMASS  ::useDefaultPartOfPool();
   FFlSPRING ::useDefaultPartOfPool();
   FFlRSPRING::useDefaultPartOfPool();

--- a/src/FFlLib/FFlVisualization/FFlVisFace.C
+++ b/src/FFlLib/FFlVisualization/FFlVisFace.C
@@ -225,6 +225,7 @@ void FFlVisFace::getElmFaceNormal(FaVec3& normal)
 
 bool FFlVisFace::isVisible() const
 {
+#ifdef FT_USE_VISUALS
   for (const FFlFaceElemRef& ref : myElementRefs)
     if (!ref.myElement->getDetail())
       return true;
@@ -232,6 +233,9 @@ bool FFlVisFace::isVisible() const
       return true;
 
   return false;
+#else
+  return true;
+#endif
 }
 
 

--- a/src/FFlrLib/CMakeLists.txt
+++ b/src/FFlrLib/CMakeLists.txt
@@ -24,6 +24,11 @@ if ( USE_MEMPOOL )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
 endif ( USE_MEMPOOL )
 
+if ( USE_VERTEXOBJ OR USE_VTFX )
+  string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_VERTEX" )
+endif ( USE_VERTEXOBJ OR USE_VTFX )
+
+
 ## Files with header and source with same name
 set ( COMPONENT_FILE_LIST FFlrFEResultBuilder FFlrFEResult
                           FFlrFringeCreator FFlrResultResolver


### PR DESCRIPTION
Since these items are relevant for the FEDEM GUI only, it is beneficial to exclude them from the solver build.